### PR TITLE
Rhc payment type create request

### DIFF
--- a/bangazon_customer_api/views/payment_types.py
+++ b/bangazon_customer_api/views/payment_types.py
@@ -68,10 +68,14 @@ class PaymentTypes(ViewSet):
                 """Handle POST operations
 
                 Returns:
-                    Response -- JSON serialized ParkArea instance
+                    Response -- JSON serialized Payment Type instance
                 """
-                newPaymentType = ParkArea()
-                newPaymentType.name = request.data["name"]
+                newPaymentType = PaymentType()
+                newPaymentType.merchant_name = request.data["merchant_name"]
+                newPaymentType.acct_number = request.data["acct_number"]
+                newPaymentType.expiration_date = request.data["expiration_date"]
+                newPaymentType.customer = request.auth.user.customer
+                newPaymentType.created_at = request.data["created_at"]
                 newPaymentType.save()
 
                 serializer = PaymentTypeSerializer(newPaymentType, context={'request': request})

--- a/bangazon_customer_api/views/payment_types.py
+++ b/bangazon_customer_api/views/payment_types.py
@@ -64,50 +64,16 @@ class PaymentTypes(ViewSet):
 
             return Response(serializer.data)
 
-    #     # this is how you handle delete with djanog. Destroy is the word or key for this method
-    #     def destroy(self, request, pk=None):
-    #         """Handle DELETE requests to payment type
+        def create(self, request):
+                """Handle POST operations
 
-    #         Return:
-    #         Response -- JSON serialized detail of deleted payment type
-    #     """
-    #     try:
-    #         paymenttype = PaymentType.objects.get(pk=pk)
-    #         paymenttype.delete()
+                Returns:
+                    Response -- JSON serialized ParkArea instance
+                """
+                newPaymentType = ParkArea()
+                newPaymentType.name = request.data["name"]
+                newPaymentType.save()
 
-    #         return Response({}, status=status.HTTP_204_NO_CONTENT)
+                serializer = PaymentTypeSerializer(newPaymentType, context={'request': request})
 
-    #     except PaymentType.DoesNotExist as ex:
-    #         return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
-
-    #     except Exception as ex:
-    #         return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-    #     def update(self, request, pk=None):
-    #         """Handle PUT requests for an individual payment type item
-    #         Returns:
-    #         Response -- Empty body with 204 status code
-    #         """
-    #     paymenttype = PaymentType.objects.get(pk=pk)
-    #     paymenttype.merchant_name = request.data["merchant_name"]
-    #     paymenttype.acct_no = request.data["acct_no"]
-    #     paymenttype.expiration_date = request.data["expiration_date"]
-    #     paymenttype.customer_id = request.auth.user.customer.id
-
-    #     paymenttype.save()
-
-    #     return Response({}, status=status.HTTP_204_NO_CONTENT)
-
-    # # Handles the creation of an object
-    #     def create(self, request):
-    #         new_paymenttype = PaymentType()
-    #         new_paymenttype.merchant_name = request.data["merchant_name"]
-    #         new_paymenttype.acct_no = request.data["acct_no"]
-    #         new_paymenttype.expiration_date = request.data["expiration_date"]
-    #         new_paymenttype.customer_id = request.auth.user.customer.id
-
-    #         new_paymenttype.save()
-
-    #         serializer = PaymentTypeSerializer(new_paymenttype, context={'request': request})
-
-    #         return Response(serializer.data)
+                return Response(serializer.data)


### PR DESCRIPTION
I added the create method to payment type view and tested adding a payment type using Postman. Do the following to test:

1. `git fetch --all`
1. `git checkout rhc-payment-type-create-request`
1.  Ensure your server is running
1. Open Postman and do a POST request to `http://[your local server address]/paymenttypes`
___NOTE:__ Ensure the user's authorization token is in the header of the request_
1. In the body of the request, enter the following details replacing the content in brackets:
```
{
    "merchant_name": "[Merchant Name]",
    "acct_number": "[Account Number]",
    "expiration_date": "[Expiration Date]",
    "created_at": "[Created at]"
}
```
6. Using TablePlus, ensure the data has been added to the Payment Types table