### PR TITLE
Implemented safe delete

### DIFF
--- a/bangazon/settings.py
+++ b/bangazon/settings.py
@@ -40,7 +40,8 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework.authtoken',
     'corsheaders',
-    'bangazon_customer_api'
+    'bangazon_customer_api',
+    'safedelete'
 ]
 
 REST_FRAMEWORK = {

--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -25,7 +25,7 @@ router = routers.DefaultRouter(trailing_slash=False)
 # router.register(r'orderproducts', OrderProducts, 'orderproduct')
 router.register(r'orders', Orders, 'order')
 router.register(r'products', Products, 'product')
-router.register(r'paymenttypes', PaymentTypes, 'paymenttypes')
+router.register(r'paymenttypes', PaymentTypes, 'paymenttype')
 router.register(r'producttypes', ProductTypes, 'producttype')
 
 urlpatterns = [

--- a/bangazon_customer_api/models/order.py
+++ b/bangazon_customer_api/models/order.py
@@ -14,7 +14,7 @@ class Order(models.Model):
     """
 
     customer = models.ForeignKey(Customer, on_delete=models.DO_NOTHING)
-    payment_type = models.ForeignKey(PaymentType, on_delete=models.DO_NOTHING, null=True)
+    payment_type = models.ForeignKey(PaymentType, on_delete=models.CASCADE, null=True)
     created_at = models.DateTimeField(auto_now=False, auto_now_add=True)
 
     class Meta:

--- a/bangazon_customer_api/models/payment_type.py
+++ b/bangazon_customer_api/models/payment_type.py
@@ -1,15 +1,20 @@
 from django.db import models
 from .customer import Customer
+from safedelete.models import SafeDeleteModel
+from safedelete.models import HARD_DELETE_NOCASCADE
 
 
-class PaymentType(models.Model):
+class PaymentType(SafeDeleteModel):
     """ This model is for payment types. Created by Erin Polley, Esq."""
+    _safedelete_policy = HARD_DELETE_NOCASCADE
 
     merchant_name = models.CharField(max_length=25)
     acct_number = models.CharField(max_length=25)
     expiration_date = models.DateTimeField(auto_now=False, auto_now_add=True)
     customer = models.ForeignKey(Customer, on_delete=models.DO_NOTHING)
     created_at = models.DateTimeField(auto_now=False, auto_now_add=True)
+
+
 
     class Meta:
         ordering = ("-created_at",)

--- a/bangazon_customer_api/views/orders.py
+++ b/bangazon_customer_api/views/orders.py
@@ -20,7 +20,7 @@ class OrdersSerializer(serializers.HyperlinkedModelSerializer):
             lookup_field='id'
         )
         fields = ('id', 'created_at', 'customer_id', 'payment_type_id')
-
+        # depth = 2
 
 class Orders(ViewSet):
     """Orders for Bangazon"""

--- a/bangazon_customer_api/views/payment_types.py
+++ b/bangazon_customer_api/views/payment_types.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from rest_framework import status
 from bangazon_customer_api.models import PaymentType, Customer
 
+
 # Required Imports for functionality Above ^ allows use of framework Viewset, Response, Serializers(what changes data type) PaymentType and Customer are Models we created for blueprints later. JB- Comment
 
 # Establishing Class for Payment Type Serializer. Converts Payment Type Data for consumption as JSON.
@@ -81,3 +82,21 @@ class PaymentTypes(ViewSet):
                 serializer = PaymentTypeSerializer(newPaymentType, context={'request': request})
 
                 return Response(serializer.data)
+
+        def destroy(self, request, pk=None):
+                """Handle DELETE requests for a single park area
+
+                Returns:
+                    Response -- 200, 404, or 500 status code
+                """
+                try:
+                    delete_payment_type = PaymentType.objects.get(pk=pk)
+                    delete_payment_type.delete()
+
+                    return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+                except PaymentType.DoesNotExist as ex:
+                    return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+                except Exception as ex:
+                    return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
I created the DELETE request for the payment type view, and I have tested deleting a payment type using Postman. To complete this ticket, I needed to install and integrate a third-party app, [Safe Delete](https://github.com/makinacorpus/django-safedelete). To check, do the following:

1. `git fetch --all`
1. `git checkout rhc-payment-type-delete-request`
1.  Ensure your server is running
1.  Ensure you have payment type data in your database
1. You may need to have Safe Delete installed in your project. To do so, do the following:
   1. In your terminal, navigate to the top level of your API app directories (i.e. the directory with manage.py)
   1. Run the following command `pip install django-safedelete`
   1. Run `python manage.py makemigrations bangazon_customer_api`
   1. Run `python manage.py migrate`
   1. Open TablePlus, navigate to the Payment Types table, and ensure there is a new column called "deleted"
1. Open Postman and do a DELETE request to `http://[your local server address]/paymenttypes/[id of payment type]`
___NOTE:__ Ensure the user's authorization token is in the header of the request_
1. In TablePlus, navigate to the Payment Types table and ensure the deleted payment type still displays but now has a time stamp in the deleted column.
___NOTE:__ Due to how Safe Delete works, an item won't be deleted entirely from the database if it has dependencies to other tables_